### PR TITLE
feat: add RefundEvent to notify when refunds are created

### DIFF
--- a/packages/core/src/event-bus/events/refund-event.ts
+++ b/packages/core/src/event-bus/events/refund-event.ts
@@ -1,0 +1,21 @@
+import { RequestContext } from '../../api/common/request-context';
+import { Order } from '../../entity/order/order.entity';
+import { Refund } from '../../entity/refund/refund.entity';
+import { VendureEvent } from '../vendure-event';
+
+/**
+ * @description
+ * This event is fired whenever a {@link Refund} is created for an order.
+ *
+ * @docsCategory events
+ * @docsPage Event Types
+ */
+export class RefundEvent extends VendureEvent {
+    constructor(
+        public ctx: RequestContext,
+        public order: Order,
+        public refund: Refund,
+    ) {
+        super();
+    }
+}

--- a/packages/core/src/event-bus/index.ts
+++ b/packages/core/src/event-bus/index.ts
@@ -47,6 +47,7 @@ export * from './events/product-variant-channel-event';
 export * from './events/product-variant-event';
 export * from './events/product-variant-price-event';
 export * from './events/promotion-event';
+export * from './events/refund-event';
 export * from './events/refund-state-transition-event';
 export * from './events/role-change-event';
 export * from './events/role-event';

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -59,7 +59,9 @@ import {
     MultipleOrderError,
     NothingToRefundError,
     PaymentOrderMismatchError,
+    RefundAmountError,
     RefundOrderStateError,
+    RefundStateTransitionError,
     SettlePaymentError,
 } from '../../common/error/generated-graphql-admin-errors';
 import {
@@ -98,6 +100,7 @@ import { CouponCodeEvent } from '../../event-bus/events/coupon-code-event';
 import { OrderEvent } from '../../event-bus/events/order-event';
 import { OrderLineEvent } from '../../event-bus/events/order-line-event';
 import { OrderStateTransitionEvent } from '../../event-bus/events/order-state-transition-event';
+import { RefundEvent } from '../../event-bus/events/refund-event';
 import { RefundStateTransitionEvent } from '../../event-bus/events/refund-state-transition-event';
 import { CustomFieldRelationService } from '../helpers/custom-field-relation/custom-field-relation.service';
 import { FulfillmentState } from '../helpers/fulfillment-state-machine/fulfillment-state';
@@ -1419,7 +1422,14 @@ export class OrderService {
             return new RefundOrderStateError({ orderState: order.state });
         }
 
-        return await this.paymentService.createRefund(ctx, input, order, payment);
+        const result = await this.paymentService.createRefund(ctx, input, order, payment);
+        
+        if (!(result instanceof RefundStateTransitionError) && 
+            !(result instanceof RefundAmountError)) {
+            await this.eventBus.publish(new RefundEvent(ctx, order, result));
+        }
+        
+        return result;
     }
 
     /**


### PR DESCRIPTION
# Add RefundEvent to notify when refunds are created

Currently, there is no event that notifies other parts of the system when a refund is created for an order. This makes it difficult to react to refund creation in a timely manner, such as updating inventory or sending notifications.

This PR adds:
1. A new `RefundEvent` class that extends `VendureEvent`
2. Updates to the OrderService to publish this event after a refund is successfully created
3. Updates to the EventBus index to export the new event

The event includes information about the order, the refund, and the context of the request, allowing subscribers to react appropriately.